### PR TITLE
stop chain and return error on unknown platform

### DIFF
--- a/lib/checkInstall.js
+++ b/lib/checkInstall.js
@@ -6,12 +6,13 @@ var async = require('async');
 
 require('./schemas/installation.js');
 var Installation = mongoose.model('Installation');
+var errors = require('./errors');
 
 module.exports = function(settings) {
 
 	function _checkInstall(req, res, cbk){
 		if(settings.installPath === "") {
-			return cbk(false);
+			return cbk(null, false);
 		}
 
 		var path = String(req.url);
@@ -29,11 +30,17 @@ module.exports = function(settings) {
 			if(platformName.indexOf('?')>0){
 				platformName = platformName.substring(0, platformName.indexOf('?'));
 			}
+
+			if (!settings.platforms || !settings.platforms[platformName] || !settings.platforms[platformName].link) {
+				res.send(400, errors.invalidPlatform);
+				return cbk(errors.invalidPlatform);
+			}
+
 			res.header('Location', settings.platforms[platformName].link);
 			res.send(302);
 
 			if(!settings.db){
-				return cbk(true);
+				return cbk(null, true);
 			}
 
 			async.series([
@@ -57,13 +64,13 @@ module.exports = function(settings) {
 					});
 				}
 			],function(){
-				cbk(true);
+				cbk(null, true);
 			});
 
 			return;
 		}
 
-		cbk(false);
+		cbk(null, false);
 	}
 
 	return _checkInstall

--- a/lib/version-control.js
+++ b/lib/version-control.js
@@ -27,7 +27,11 @@ module.exports = function (settings) {
 		var path = String(req.url);
 		debug('version control for path \'' + path + '\'');
 
-		_checkInstall(req, res, function (isInstallPath) {
+		_checkInstall(req, res, function (err, isInstallPath) {
+			if (err) {
+				return next(err);
+			}
+
 			if (isInstallPath === true) {
 				return next(false);
 			}


### PR DESCRIPTION
Send error response for unknown platforms. Ex: if you try to install the app from `/install/UNKNOWN_PLATFORM` it'll response with an error instead of a timeout.
